### PR TITLE
fix lukaword computation

### DIFF
--- a/src/decision_tree/treeClasses.cpp
+++ b/src/decision_tree/treeClasses.cpp
@@ -93,7 +93,7 @@ const string LeafNode::toDotString() const
  */
 const string &LeafNode::calculateLukasWord()
 {
-    return setLukasWord("(" + valueToString() + ")");
+    return setLukasWord(valueToString());
 }
 
 /**
@@ -130,7 +130,7 @@ const string InternalNode::toDotString() const
  */
 const string &InternalNode::calculateLukasWord()
 {
-    return setLukasWord("(" + _left->calculateLukasWord() + _right->calculateLukasWord() + ")");
+    return setLukasWord("(" + _left->calculateLukasWord() + ")" + "(" +_right->calculateLukasWord() + ")");
 }
 
 /**

--- a/src/tests/tree.test.cpp
+++ b/src/tests/tree.test.cpp
@@ -4,8 +4,11 @@
 void test_tree_build()
 {
     BinaryDecisionTree test(38, 8);
-    test.BasicCompression();
+    //test.BasicCompression();
     cout << test.getLukasWord() << endl;
+    string expected_luka_word = "(((false)(true))((true)(false)))(((false)(true))((false)(false)))"; 
+    cout << expected_luka_word << endl;
+    assert(test.getLukasWord() == expected_luka_word && "test luka word");
 }
 
 int main(int argc, const char **argv)

--- a/src/tests/tree.test.cpp
+++ b/src/tests/tree.test.cpp
@@ -1,18 +1,30 @@
 #include "../decision_tree/tree.h"
 #include <assert.h>
 
+
 void test_tree_build()
 {
     BinaryDecisionTree test(38, 8);
-    //test.BasicCompression();
-    cout << test.getLukasWord() << endl;
+}
+
+void test_lukaword_computation()
+{
+    BinaryDecisionTree tree(38, 8);
+    BinaryDecisionTree tree2(2, 2);
     string expected_luka_word = "(((false)(true))((true)(false)))(((false)(true))((false)(false)))"; 
-    cout << expected_luka_word << endl;
-    assert(test.getLukasWord() == expected_luka_word && "test luka word");
+    string expected_luka_word2 = "(false)(true)"; 
+
+    assert(tree.getLukasWord() == expected_luka_word && "test luka for table of 38");
+    assert(tree2.getLukasWord() == expected_luka_word2 && "test luka for table of 2");
+    
+    // assert not
+    assert(tree.getLukasWord() != expected_luka_word2 && "test luka for table of 38");
+    assert(tree2.getLukasWord() != expected_luka_word && "test luka for table of 2");
 }
 
 int main(int argc, const char **argv)
 {
-    test_tree_build();
+    //test_tree_build();
+    test_lukaword_computation();
     return 0;
 }


### PR DESCRIPTION
```
for:
  a -> true
  a -> false
we have:
  a(true)(false)
instead of:
  (a(true)(false))
```